### PR TITLE
Add notebook requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+cdcs~=0.1
+pandas~=1.4
+lxml~=4.8
+requests~=2.27
+matplotlib~=3.5


### PR DESCRIPTION
This PR adds a Python requirements file such that the notebook can be used more easily on e.g. Binder or Colab.
